### PR TITLE
Added USER environment variable to start rabbimq with a preconficured username

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 tutum-docker-rabbitmq
 =====================
 
-Base docker image to run a RabbitMQ server, forked from tutum/rabbitmq (https://github.com/tutumcloud/tutum-docker-rabbitmq) and extended with configurable username.
+Base docker image to run a RabbitMQ server
 
 
 Usage
 -----
 
-To create the image `mminder/rabbitmq`, execute the following command on the tutum-rabbitmq folder:
+To create the image `tutum/rabbitmq`, execute the following command on the tutum-rabbitmq folder:
 
-	sudo docker build -t mminder/rabbitmq .
+	sudo docker build -t tutum/rabbitmq .
 
 
 Running the RabbitMQ server
@@ -17,7 +17,7 @@ Running the RabbitMQ server
 
 Run the following command to start rabbitmq:
 
-	docker run -d -p 5672:5672 -p 15672:15672 mminder/rabbitmq
+	docker run -d -p 5672:5672 -p 15672:15672 tutum/rabbitmq
 
 The first time that you run your container, a new random password will be set.
 To get the password, check the logs of the container by running:
@@ -34,7 +34,7 @@ You will see an output like the following:
 	Please remember to change the above password as soon as possible!
 	========================================================================
 
-In this case, `5elsT6KtjrqV` is the password set and 'admin' is the default user.
+In this case, `5elsT6KtjrqV` is the password set. 
 You can then connect to RabbitMQ:
 
 	rabbitmqadmin -u admin -p 5elsT6KtjrqV -P 15672 list vhosts
@@ -45,11 +45,11 @@ Done!
 Setting a specific password for the admin account
 -------------------------------------------------
 
-If you want to use a preset user and/or password instead of 'admin' and a randomly generated password, you can
-set the environment variables `RABBITMQ_USER` and `RABBITMQ_PASS` to your specific username and/or password when running the container:
+If you want to use a preset password instead of a randomly generated one, you can
+set the environment variable `RABBITMQ_PASS` to your specific password when running the container:
 
-	docker run -d -p 5672:5672 -p 15672:15672 -e RABBITMQ_USER="myuser" -e RABBITMQ_PASS="mypass" mminder/rabbitmq
+	docker run -d -p 5672:5672 -p 15672:15672 -e RABBITMQ_PASS="mypass" tutum/rabbitmq
 
-You can now test your new credentials:
+You can now test your new admin password:
 
-	rabbitmqadmin -u myuser -p mypass -P 15672 list vhosts
+	rabbitmqadmin -u admin -p mypass -P 15672 list vhosts


### PR DESCRIPTION
Hi

We added a USER environment variable enabling us to start docker with a specific username (not "admin"). Please merge because we would really like to use your rabbitmq docker in the future :)

example:
docker run -d -p 5672:5672 -p 15672:15672 -e RABBITMQ_USER="guest" -e RABBITMQ_PASS="mypass" tutum/rabbitmq
