### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,8 @@
 if [ ! -f /.rabbitmq_password_set ]; then
 	/set_rabbitmq_password.sh
 fi
+
+# make rabbit own its own files
+chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
+
 exec /usr/sbin/rabbitmq-server


### PR DESCRIPTION
I saw issues where rabbitmq could not write the pid file when using a volume to the local machine. When it owns its own dir and is no longer owned by I could no longer replicate.
