### PR TITLE
Add cluster feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F7B8CEA6056E8E56 &&
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN echo "ERLANGCOOKIE" > /var/lib/rabbitmq/.erlang.cookie
+RUN chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie
+RUN chmod 400 /var/lib/rabbitmq/.erlang.cookie
+
 # Add scripts
 ADD run.sh /run.sh
 ADD set_rabbitmq_password.sh /set_rabbitmq_password.sh

--- a/README.md
+++ b/README.md
@@ -53,3 +53,32 @@ set the environment variable `RABBITMQ_PASS` to your specific password when runn
 You can now test your new admin password:
 
         curl --user admin:mypass  http://<host>:<port>/api/vhosts
+
+
+Running a RabbitMQ cluster
+--------------------------
+
+Tu run a cluster with all the DNS-Reachable Host, you have to set RABBITMQ_USE_LONGNAME 
+and HOSTNAME on first server :
+
+```
+docker run --name tutum/rabbitmq -d \
+ -p 5672:5672 -p 15672:15672 -p 35197:35197 -p 4369:4369 -p 25672:25672 \
+ -v /rabbitmqdata:/var/lib/rabbitmq/mnesia \
+ -e HOSTNAME=node1.host.io \
+ -e RABBITMQ_USE_LONGNAME=true \
+ tutum/rabbitmq
+```
+
+And add CLUSTER_WITH for the others nodes :
+
+```
+docker run --name tutum/rabbitmq -d \ 
+ -p 5672:5672 -p 15672:15672 -p 35197:35197 -p 4369:4369 -p 25672:25672 \ 
+ -v /rabbitmqdata:/var/lib/rabbitmq/mnesia \ 
+ -e HOSTNAME=node2.host.io \ 
+ -e RABBITMQ_USE_LONGNAME=true \ 
+ -e CLUSTER_WITH=node1.host.io \ 
+ tutum/rabbitmq
+```
+

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ else
         rabbitmqctl stop_app
         rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
         rabbitmqctl start_app
-        tail -f /var/log/rabbitmq/rabbit\@$HOSTNAME.log
+        tail -F /var/log/rabbitmq/rabbit\@$HOSTNAME.log
     fi
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,18 @@ fi
 # make rabbit own its own files
 chown -R rabbitmq:rabbitmq /var/lib/rabbitmq
 
-exec /usr/sbin/rabbitmq-server
+if [ -z "$CLUSTER_WITH" ] ; then
+    /usr/sbin/rabbitmq-server
+else
+    if [ -f /.CLUSTERED ] ; then
+        /usr/sbin/rabbitmq-server
+    else
+        touch /.CLUSTERED
+        /usr/sbin/rabbitmq-server -detached
+        rabbitmqctl stop_app
+        rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
+        rabbitmqctl start_app
+        tail -f /var/log/rabbitmq/rabbit\@$HOSTNAME.log
+    fi
+fi
+


### PR DESCRIPTION
To create a rabbitmq cluster not only with short names (that is to put a short_hostname->ip line in the /etc/hosts and use `--net=host` in docker cli), you must : 
 
* set RABBITMQ_USE_LONGNAME et HOSTNAME in environment variables
* Add three mort ports :  35197, 4369 and 25672
* use persistent volumes because of the clustering informations when restarting a node in the cluster