### PR TITLE
Added the ability for clustered types and management_agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:trusty
-MAINTAINER Fernando Mayo <fernando@tutum.co>
+MAINTAINER Ramon Brooker <rbrooker@aetherealmind.com>
+#MAINTAINER Fernando Mayo <fernando@tutum.co>
 
 # Install RabbitMQ
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F7B8CEA6056E8E56 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM tutum/rabbitmq:latest 
-# FROM ubuntu:trusty
-MAINTAINER Ramon Brooker <rbrooker@aetherealmind.com>
-#MAINTAINER Fernando Mayo <fernando@tutum.co>
+FROM ubuntu:trusty
+
+MAINTAINER Fernando Mayo <fernando@tutum.co>
 
 # Install RabbitMQ
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F7B8CEA6056E8E56 && \
@@ -21,5 +20,5 @@ ADD run.sh /run.sh
 ADD set_rabbitmq_password.sh /set_rabbitmq_password.sh
 RUN chmod 755 ./*.sh
 
-EXPOSE 5672 15672
+EXPOSE 5672 15672 4369 25672 
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:trusty
+FROM tutum/rabbitmq:latest 
+# FROM ubuntu:trusty
 MAINTAINER Ramon Brooker <rbrooker@aetherealmind.com>
 #MAINTAINER Fernando Mayo <fernando@tutum.co>
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run -d \
  tutum/rabbitmq
 ```
 
-And add `CLUSTER_WITH` for the others nodes :
+And add `CLUSTER_WITH` for the others nodes and `NODE_TYPE` :
 
 ```
 docker run -d \
@@ -77,6 +77,7 @@ docker run -d \
  -e HOSTNAME=node2.host.io \
  -e RABBITMQ_USE_LONGNAME=true \
  -e CLUSTER_WITH=node1.host.io \
+ -e NODE_TYPE=ram \
  tutum/rabbitmq
 ```
 RabbitMQ cluster stack file with Tutum

--- a/run.sh
+++ b/run.sh
@@ -26,6 +26,7 @@ else
         fi
         rabbitmqctl start_app
         fg
+        rabbitmq-plugins disable rabbitmq_managment
         rabbitmq-plugins enable rabbitmq_management_agent
         /usr/sbin/rabbitmq-server stop
     fi

--- a/run.sh
+++ b/run.sh
@@ -22,10 +22,13 @@ else
         if [ -z "$NODE_TYPE" ] ; then
           rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
         else 
-          rabbitmqctl join_cluster $NODE_TYPE rabbit@$CLUSTER_WITH
+          rabbitmqctl join_cluster --$NODE_TYPE rabbit@$CLUSTER_WITH
         fi
         rabbitmqctl start_app
         fg
+        rabbitmq-plugins enable rabbitmq_management_agent
+        /usr/sbin/rabbitmq-server stop
     fi
+    /usr/sbin/rabbitmq-server
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,11 @@ else
         /usr/sbin/rabbitmq-server &
         sleep 10
         rabbitmqctl stop_app
-        rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
+        if [ -z "$NODE_TYPE" ] ; then
+          rabbitmqctl join_cluster rabbit@$CLUSTER_WITH
+        else 
+          rabbitmqctl join_cluster $NODE_TYPE rabbit@$CLUSTER_WITH
+        fi
         rabbitmqctl start_app
         fg
     fi


### PR DESCRIPTION

Added the 
management_agent for Clustered Nodes
Usage: 
`-e NODE_TYPE="ram"` or `-e NODE_TYPE="disc"`


I also exposed the required ports for clustering